### PR TITLE
fixed bug resulting in mode desync, causing fuse to fail

### DIFF
--- a/pkg/fuse/attr.go
+++ b/pkg/fuse/attr.go
@@ -123,8 +123,6 @@ func (d *Dir) Setattr(ctx context.Context, req *fuse.SetattrRequest, res *fuse.S
 		return err
 	}
 
-	metadata.Mode ^= int64(os.ModeDir)
-
 	if err := Backend.SetMetadataForInode(d.db, d.inode, metadata); err != nil {
 		log.Println("Failed to set metadata in setattr!")
 		return err


### PR DESCRIPTION
type bits in mode bitplane will now be cleared before DB entry and re-created on export using the "type" column
plan to move these functionality to `attr.go`